### PR TITLE
Allow spaces in book names

### DIFF
--- a/src/js/steps/letters/generateHtml.js
+++ b/src/js/steps/letters/generateHtml.js
@@ -102,7 +102,7 @@ function combineLetters(splitLetters, dataLetters) {
     if (splitLetters.length > 5) {
       idx = i - offset;
     }
-    if (val === '-') {
+    if (val === '-' || val === ' ') {
       offset++;
       return { letter: val };
     }

--- a/test/loading.spec.js
+++ b/test/loading.spec.js
@@ -291,4 +291,22 @@ describe('Loading Monkey', function () {
       spans.length.should.equal(4);
     });
   });
+
+  it('should generate letters for names with spaces (slow)', function () {
+    var monkey = new Monkey($('<div />').attr('data-key', 'lmn-book'), {
+      book: {
+        name: 'Lee T',
+        gender: 'girl',
+        locale: 'en-GB'
+      }
+    });
+
+    return monkey.promise
+    .then(Monkey.letters._generateHtml(options))
+    .then(function (data) {
+      var spans = data.lettersElement.find('.letter');
+      spans.length.should.equal(5 + 2);
+      spans.find('.char')[4].should.match(/ /);
+    });
+  });
 });


### PR DESCRIPTION
Adds the ability to create preview books that have spaces in the names.

<img width="676" alt="screen shot 2015-07-13 at 17 29 27" src="https://cloud.githubusercontent.com/assets/354592/8654811/ba7259a8-2984-11e5-8649-bfa28642e6fa.png">
