### PR TITLE
Makes spaces and hyphens not clickable on desktop name links

### DIFF
--- a/src/js/steps/letters/generateHtml.js
+++ b/src/js/steps/letters/generateHtml.js
@@ -49,6 +49,12 @@ module.exports = function (options) {
 
     $(combinedLetters).each(function (i, letter) {
       var $letterDiv = $('<div />');
+
+      // Ensures spaces and hyphens are not clickable in double barrel names
+      if (letter.letter === ' ' || letter.letter === '-') {
+        $letterDiv.addClass('special-char nonclickable');
+      }
+
       $letterDiv.appendTo($letters)
         .addClass('letter')
         .after(' ');

--- a/src/js/steps/letters/init.js
+++ b/src/js/steps/letters/init.js
@@ -41,7 +41,7 @@ module.exports = function ($events, options) {
       }
     });
 
-    $letters.on('click', '.letter', function () {
+    $letters.on('click', '.letter:not(.nonclickable)', function () {
       var $this = $(this);
       var charsBefore = $this.prevAll('.special-char').length;
       data.turnToPage($this.index() - charsBefore);

--- a/test/desktop.spec.js
+++ b/test/desktop.spec.js
@@ -54,4 +54,36 @@ describe('Using monkey on desktop', function () {
   after(function () {
     $container.remove();
   });
+
+  describe('Special Characters for separating names', function () {
+    var data, monkey;
+    var $container = $('<div />').attr('data-key', 'lmn-book');
+
+    before(function () {
+      options.book.name = 'Mary Mary-Jane';
+      this.timeout(4000);
+
+      monkey = new Monkey($container, {
+        monkeyType: 'desktop',
+        book: options.book
+      });
+
+      return monkey.promise.then(function (dataa) {
+        $container.appendTo('body');
+        data = dataa;
+      });
+    });
+
+    it('should not make hyphens in names clickable', function () {
+      $container.find('.nonclickable.special-char .char:contains(-)').length.should.equal(1);
+    });
+
+    it('should not make spaces in names clickable', function () {
+      $container.find('.nonclickable.special-char .char:contains( )').length.should.equal(1);
+    });
+
+    after(function () {
+      $container.remove();
+    });
+  });
 });


### PR DESCRIPTION
If a user clicks the letter links above the preview it shows the next possible letter's page which makes the active link out of synch with the book preview.

## Before 
<img width="1173" alt="screen shot 2015-07-15 at 08 50 57" src="https://cloud.githubusercontent.com/assets/354592/8693376/9c574fbe-2ace-11e5-8334-40cf5ae59601.png">

## After 

<img width="1196" alt="screen shot 2015-07-15 at 08 52 04" src="https://cloud.githubusercontent.com/assets/354592/8693404/c7a3dce6-2ace-11e5-851b-1f0422e8c887.png">
