### PR TITLE
Feature/heidelberg update

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babelify": "^6.1.2",
     "diacritics": "^1.2.1",
-    "heidelberg": "git://github.com/Lostmyname/heidelberg#797691c99759b0ef63152baf736eb2081983acf7",
+    "heidelberg": "git://github.com/Lostmyname/heidelberg#c6a555e31b9dde1f6d8c2bb47cd7e5a2dea40033",
     "jquery": "^1.11.2",
     "lang": "^0.1.1",
     "nums": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "lmn-monkey",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "",
   "main": "src/js/monkey.js",
   "dependencies": {
     "babelify": "^6.1.2",
     "diacritics": "^1.2.1",
-    "heidelberg": "git://github.com/Lostmyname/heidelberg#ccf08d98d94eac01c672ebd9b730b09060645a80",
+    "heidelberg": "git://github.com/Lostmyname/heidelberg#62f47d3ced431af5e0dbd730e3d2224fbafcdbb9",
     "jquery": "^1.11.2",
     "lang": "^0.1.1",
     "nums": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babelify": "^6.1.2",
     "diacritics": "^1.2.1",
-    "heidelberg": "^1.0.5",
+    "heidelberg": "git://github.com/Lostmyname/heidelberg#797691c99759b0ef63152baf736eb2081983acf7",
     "jquery": "^1.11.2",
     "lang": "^0.1.1",
     "nums": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmn-monkey",
-  "version": "5.1.2",
+  "version": "5.2.1",
   "description": "",
   "main": "src/js/monkey.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babelify": "^6.1.2",
     "diacritics": "^1.2.1",
-    "heidelberg": "git://github.com/Lostmyname/heidelberg#62f47d3ced431af5e0dbd730e3d2224fbafcdbb9",
+    "heidelberg": "^1.0.6",
     "jquery": "^1.11.2",
     "lang": "^0.1.1",
     "nums": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "lmn-monkey",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "",
   "main": "src/js/monkey.js",
   "dependencies": {
     "babelify": "^6.1.2",
     "diacritics": "^1.2.1",
-    "heidelberg": "git://github.com/Lostmyname/heidelberg#c6a555e31b9dde1f6d8c2bb47cd7e5a2dea40033",
+    "heidelberg": "git://github.com/Lostmyname/heidelberg#ccf08d98d94eac01c672ebd9b730b09060645a80",
     "jquery": "^1.11.2",
     "lang": "^0.1.1",
     "nums": "^1.0.0"


### PR DESCRIPTION
- Switch monkey to use latest updates to heidelberg, which make it compatible with JHome, fixes a bug with IE10, and reduces flickering with turning pages on some GPU configurations 

- Use LMN/heidelberg branch instead of DJGrant's branch