### PR TITLE
Use jQuery class rather than react className for the screen reader link

### DIFF
--- a/src/js/monkeys/desktop.js
+++ b/src/js/monkeys/desktop.js
@@ -29,7 +29,7 @@ desktop.generateHtml = function (data, lang) {
 
   $('<a />', {
     href: '#skip-preview',
-    className: 'for-screen-reader'
+    class: 'for-screen-reader'
   })
     .text('Skip book preview')
     .appendTo($monkeyWrapper);


### PR DESCRIPTION
Currently it compiles to `<a classname="for-screen-reader">` so it breaks visibility.