### PR TITLE
Fix the annoying u.turnToPage bug

### DIFF
--- a/src/js/steps/initMonkey.js
+++ b/src/js/steps/initMonkey.js
@@ -18,7 +18,7 @@ module.exports = function ($events, options) {
       $events.trigger('clearCharSelection');
     }
     data.turnToPage = this.monkeys[data.monkeyType].init(data, $events, options);
-
+    data.canTurnPage = true;
     return data;
   }.bind(this);
 };

--- a/src/js/steps/letters/init.js
+++ b/src/js/steps/letters/init.js
@@ -334,6 +334,9 @@ module.exports = function ($events, options, $monkeyContainer) {
       if ($monkey.hasClass('js--active-overlay')) {
         return false;
       }
+      if (!data.canTurnPage) {
+        return;
+      }
       // Add a destroy listener so that anywhere the user clicks the picker will
       // hide.
       $('html').one('click', function () {


### PR DESCRIPTION
Basically, it was caused by people clicking on the letters of the name before monkey was fully initiated.

Adding a flag variable so that the functions when you click only run once Monkey has initiated fixes this.