### PR TITLE
Keep monkey preview height during loading

### DIFF
--- a/src/js/monkey.js
+++ b/src/js/monkey.js
@@ -70,7 +70,8 @@
     if (options.letters) {
       promise = promise
         .then(Monkey._generateBaseElement($monkeyContainer, options))
-        .then(Monkey.letters._generateHtml(options));
+        .then(Monkey.letters._generateHtml(options))
+        .then(Monkey._generateBaseWrapperElement($monkeyContainer, options));
 
       if (options.showCharPicker) {
         promise = promise
@@ -131,6 +132,7 @@
 
   Monkey._getData = require('./steps/getData');
   Monkey._generateBaseElement = require('./steps/generateBaseElement');
+  Monkey._generateBaseWrapperElement = require('./steps/generateBaseWrapperElement');
   Monkey._calculateMonkey = require('./steps/calculateMonkey');
   Monkey._generateUrls = require('./steps/generateUrls');
   Monkey._generatePlatformUrls = require('./steps/generatePlatformUrls');

--- a/src/js/monkeys/desktop.js
+++ b/src/js/monkeys/desktop.js
@@ -19,8 +19,9 @@ desktop.calculateSize = function () {
  * @return {HTMLElement}      The monkey wrapper.
  */
 desktop.generateHtml = function (data, lang) {
-  var $monkeyWrapper = $('<div />')
-    .addClass('pos-relative positioned-relative monkey-wrapper desktop');
+  console.log(data);
+  // var $monkeyWrapper = $('<div />')
+  //   .addClass('pos-relative positioned-relative monkey-wrapper desktop');
   var $monkey = $('<div />').addClass('Heidelberg-Book with-Spreads pos-absolute positioned-absolute');
 
   if (data.spreads === 'double') {
@@ -32,7 +33,7 @@ desktop.generateHtml = function (data, lang) {
     className: 'for-screen-reader'
   })
     .text('Skip book preview')
-    .appendTo($monkeyWrapper);
+    .appendTo(data.$monkeyWrapper);
 
   $.each(data.urls, function (i, url) {
     var $img = $('<img />', {
@@ -48,11 +49,11 @@ desktop.generateHtml = function (data, lang) {
 
     $img.attr('data-id', data.letters[i].id);
   });
-  $monkey.appendTo($monkeyWrapper);
+  $monkey.appendTo(data.$monkeyWrapper);
 
-  $('<span />', { id: 'skip-preview' }).appendTo($monkeyWrapper);
+  $('<span />', { id: 'skip-preview' }).appendTo(data.$monkeyWrapper);
 
-  return $monkeyWrapper;
+  return data.$monkeyWrapper;
 };
 
 // @todo document this.

--- a/src/js/monkeys/desktop.js
+++ b/src/js/monkeys/desktop.js
@@ -19,9 +19,6 @@ desktop.calculateSize = function () {
  * @return {HTMLElement}      The monkey wrapper.
  */
 desktop.generateHtml = function (data, lang) {
-  console.log(data);
-  // var $monkeyWrapper = $('<div />')
-  //   .addClass('pos-relative positioned-relative monkey-wrapper desktop');
   var $monkey = $('<div />').addClass('Heidelberg-Book with-Spreads pos-absolute positioned-absolute');
 
   if (data.spreads === 'double') {

--- a/src/js/monkeys/mobile.js
+++ b/src/js/monkeys/mobile.js
@@ -20,8 +20,7 @@ mobile.calculateSize = function () {
  * @return {HTMLElement}      The monkey wrapper.
  */
 mobile.generateHtml = function (data, lang) {
-  var $monkey = $('<div />').addClass('monkey-wrapper mobile');
-  var $images = $('<div />').appendTo($monkey)
+  var $images = $('<div />').appendTo(data.$monkeyWrapper)
     .addClass('landscape-images');
   var $inner = $('<div />').appendTo($images)
     .addClass('landscape-images-inner');
@@ -45,7 +44,7 @@ mobile.generateHtml = function (data, lang) {
     }).appendTo($page);
   });
 
-  return $monkey;
+  return data.$monkeyWrapper;
 };
 /*eslint-disable no-unused-vars */
 mobile.generateBaseElement = function (data) {

--- a/src/js/monkeys/mobile.js
+++ b/src/js/monkeys/mobile.js
@@ -20,22 +20,27 @@ mobile.calculateSize = function () {
  * @return {HTMLElement}      The monkey wrapper.
  */
 mobile.generateHtml = function (data, lang) {
-  var $images = $('<div />').appendTo(data.$monkeyWrapper)
+  var $images = $('<div />')
+    .appendTo(data.$monkeyWrapper)
     .addClass('landscape-images');
-  var $inner = $('<div />').appendTo($images)
+  var $inner = $('<div />')
+    .appendTo($images)
     .addClass('landscape-images-inner');
 
   // For each image URL we get passed, create the image and add it to the page.
   $.each(data.urls, function (i, url) {
-    var $page = $('<div />').appendTo($inner)
+    var $page = $('<div />')
+      .appendTo($inner)
       .addClass('page page-' + data.letters[i].type + ' Page-' + i);
 
     if (i === 0) {
-      $page.addClass('page-first page-halfwidth');
+      $page
+        .addClass('page-first page-halfwidth');
     }
 
     if (i === data.urls.length - 1) {
-      $page.addClass('page-halfwidth');
+      $page
+        .addClass('page-halfwidth');
     }
 
     $('<img />', {
@@ -48,7 +53,8 @@ mobile.generateHtml = function (data, lang) {
 };
 /*eslint-disable no-unused-vars */
 mobile.generateBaseElement = function (data) {
-  return $('<div />').addClass('monkey mobile');
+  return $('<div />')
+    .addClass('monkey mobile');
 };
 /*eslint-enable no-unused-vars */
 

--- a/src/js/steps/generateBaseWrapperElement.js
+++ b/src/js/steps/generateBaseWrapperElement.js
@@ -1,0 +1,47 @@
+'use strict';
+var $ = require('jquery');
+
+/**
+ * Generate base HTML element for all of monkey.
+ *
+ * Varies depending on the browser.
+ *
+ */
+module.exports = function ($monkeyContainer, options) {
+  return function (data) {
+    //
+    // var html = {
+    //   desktop: function () {
+    //
+    //   },
+    //   mobile: function () {
+    //
+    //   }
+    // };
+    // // Attach a cloned version of the loading gif to the data object, so we can
+    // // use it later.
+    // data.loading = monkeyContainer.find('.loader-img').clone();
+    // // Remove all DOM elements within the container (needed for
+    // // re-initialisation when changing name in the edit screen)
+    // monkeyContainer.empty();
+    //
+    // // If replaceMonkey is true (which means a user has changed the name/gender/
+    // // language of a book on the product page) then append the loading gif to
+    // // the container – so the user has visible feedback that something is
+    // // loading in.
+    // if (options.replaceMonkey) {
+    //   data.loading = data.loading.appendTo(monkeyContainer);
+    // }
+    // // Add either a desktop/mobile CSS class to the container, and attach the
+    // // container element to the data object.
+    // monkeyContainer.addClass(data.monkeyType);
+    // data.monkeyContainer = monkeyContainer;
+    // if (data.monkeyType ===)
+    // console.log(monkeyContainer);
+    data.$monkeyWrapper = $('<div />')
+      .addClass('pos-relative positioned-relative monkey-wrapper desktop');
+    data.$monkeyWrapper.appendTo($monkeyContainer);
+
+    return data;
+  };
+};

--- a/src/js/steps/generateBaseWrapperElement.js
+++ b/src/js/steps/generateBaseWrapperElement.js
@@ -9,13 +9,11 @@ var $ = require('jquery');
  */
 module.exports = function ($monkeyContainer) {
   return function (data) {
-    if (data.monkeyType === 'mobile') {
-      data.$monkeyWrapper = $('<div />').addClass('monkey-wrapper mobile');
-    } else {
-      data.$monkeyWrapper = $('<div />')
-        .addClass('pos-relative positioned-relative monkey-wrapper desktop');
-    }
+    var classes = data.monkeyType === 'mobile' ?
+                  'monkey-wrapper mobile' :
+                  'positioned-relative pos-relative monkey-wrapper desktop';
 
+    data.$monkeyWrapper = $('<div />').addClass(classes);
     data.$monkeyWrapper.appendTo($monkeyContainer);
 
     return data;

--- a/src/js/steps/generateBaseWrapperElement.js
+++ b/src/js/steps/generateBaseWrapperElement.js
@@ -7,39 +7,15 @@ var $ = require('jquery');
  * Varies depending on the browser.
  *
  */
-module.exports = function ($monkeyContainer, options) {
+module.exports = function ($monkeyContainer) {
   return function (data) {
-    //
-    // var html = {
-    //   desktop: function () {
-    //
-    //   },
-    //   mobile: function () {
-    //
-    //   }
-    // };
-    // // Attach a cloned version of the loading gif to the data object, so we can
-    // // use it later.
-    // data.loading = monkeyContainer.find('.loader-img').clone();
-    // // Remove all DOM elements within the container (needed for
-    // // re-initialisation when changing name in the edit screen)
-    // monkeyContainer.empty();
-    //
-    // // If replaceMonkey is true (which means a user has changed the name/gender/
-    // // language of a book on the product page) then append the loading gif to
-    // // the container – so the user has visible feedback that something is
-    // // loading in.
-    // if (options.replaceMonkey) {
-    //   data.loading = data.loading.appendTo(monkeyContainer);
-    // }
-    // // Add either a desktop/mobile CSS class to the container, and attach the
-    // // container element to the data object.
-    // monkeyContainer.addClass(data.monkeyType);
-    // data.monkeyContainer = monkeyContainer;
-    // if (data.monkeyType ===)
-    // console.log(monkeyContainer);
-    data.$monkeyWrapper = $('<div />')
-      .addClass('pos-relative positioned-relative monkey-wrapper desktop');
+    if (data.monkeyType === 'mobile') {
+      data.$monkeyWrapper = $('<div />').addClass('monkey-wrapper mobile');
+    } else {
+      data.$monkeyWrapper = $('<div />')
+        .addClass('pos-relative positioned-relative monkey-wrapper desktop');
+    }
+
     data.$monkeyWrapper.appendTo($monkeyContainer);
 
     return data;

--- a/src/partials/partial.erb.html
+++ b/src/partials/partial.erb.html
@@ -1,17 +1,19 @@
-<div data-key="lmn-book" data-name="<%= customisation.name %>"
-  data-first-book-name="Adele" data-first-book-gender="boy" data-first-book-locale="en-GB"
-  data-show-picker="true"
-  data-show-overlay="true"
-  data-gender="<%= customisation.gender %>" data-locale="<%= customisation.locale %>"
-  data-character-selection='[{"letter":"A","character":"Aardvark"},{"letter":"N","character":"Narwhal"},{"letter":"D","character":"Dragon"},{"letter":"R","character":"Robot"},{"letter":"E","character":"Elk"},{"letter":"W","character":"Wizard"}]'
-  class="lmn-book monkey" id="monkey">
-  <div class="color-bg-white lg-pad aligned-center loader-img">
-    <%= image_tag('loading-32x32.gif', { width: 32, class: 'padded-bottom' }) %>
-    <h6 class="not-strong color-white"><%= t("loading") %></h6>
+<div style="margin: 0 auto; max-width: 1004px;">
+  <div data-key="lmn-book" data-name="<%= customisation.name %>"
+    data-first-book-name="Adele" data-first-book-gender="boy" data-first-book-locale="en-GB"
+    data-show-picker="true"
+    data-show-overlay="true"
+    data-gender="<%= customisation.gender %>" data-locale="<%= customisation.locale %>"
+    data-character-selection='[{"letter":"A","character":"Aardvark"},{"letter":"N","character":"Narwhal"},{"letter":"D","character":"Dragon"},{"letter":"R","character":"Robot"},{"letter":"E","character":"Elk"},{"letter":"W","character":"Wizard"}]'
+    class="lmn-book monkey" id="monkey">
+    <div class="color-bg-white lg-pad aligned-center loader-img">
+      <%= image_tag('loading-32x32.gif', { width: 32, class: 'padded-bottom' }) %>
+      <h6 class="not-strong color-white"><%= t("loading") %></h6>
+    </div>
   </div>
-</div>
 
-<span class="italic p pos-relative color-text-disabled display-none-on-md lmn-book__label">
-  <%= t("preview") %>
-  <%= image_tag('arrow-3-50x35.svg', { class: 'arrow-image' }) %>
-</span>
+  <span class="italic p pos-relative color-text-disabled display-none-on-md lmn-book__label">
+    <%= t("preview") %>
+    <%= image_tag('arrow-3-50x35.svg', { class: 'arrow-image' }) %>
+  </span>
+</div>


### PR DESCRIPTION
By injecting the `.monkey-wrapper` element before the images load, we can ensure that the preview will always have a predictable height, even if the preview fails to load.

Tested as a standalone within the Monkey repo, and symlinked to the Phoenix repo.