### PR TITLE
Switch Deutsch Eszett (ß) character for SS

### DIFF
--- a/src/js/steps/letters/generateHtml.js
+++ b/src/js/steps/letters/generateHtml.js
@@ -44,7 +44,8 @@ module.exports = function (options) {
       .addClass('strong')
       .attr('id', 'letters');
 
-    var letters = data.name.split('');
+    // This checks for Eszett character and replaces it with double S's
+    var letters = data.name.replace(/ß/g, 'SS').split('');
 
     // Get the total letters, by finding just the first part of each letter
     var dataLetters = $(data.letters).filter(function (i, letter) {


### PR DESCRIPTION
As we are turning on character picker for Deutsch languages we need to deal with the Eszett (ß) character, this character is not seen in any first names of Deutsch names but can appear in there surname and we have found a few customers using the surname as the name used in the book. 

This simply switches it out the ß for two S's, this is how this is most commonly translated and after speaking to the German angels, a suitable switch.