### PR TITLE
Prevent Monkey hiding stuff it knows nuthin about

### DIFF
--- a/src/js/steps/letters/generateOverlay.js
+++ b/src/js/steps/letters/generateOverlay.js
@@ -39,7 +39,7 @@ module.exports = function (options, $events) {
       // it's nonsensical to have a label to 'Tap to Preview' when you, at that
       // stage, can't.
       $monkeyContainer
-        .next()
+        .next('.italic')
         .hide();
 
       var $overlayContent = $('<div />')
@@ -138,7 +138,7 @@ module.exports = function (options, $events) {
           data.updateCharSelection();
         }
         $monkeyContainer
-          .next()
+          .next('.italic')
           .removeAttr('style');
         $('.letter').removeClass('changed');
         $('.letter-spans').animate({


### PR DESCRIPTION
Fixes the bug where the bar tabs are hidden when an overlay is shown.

Used the `.italic` selector to be consistent with the rest of the codebase.