### PR TITLE
Fix TJH preview with platformAPI option

### DIFF
--- a/src/js/monkey.js
+++ b/src/js/monkey.js
@@ -81,8 +81,13 @@
           )
         );
       }
-
       promise = promise.then(Monkey.letters._init(this.$events, options, $monkeyContainer));
+    }
+
+    if (this.options.platformAPI) {
+      promise = promise
+        .then(Monkey._generateBaseElement($monkeyContainer, options))
+        .then(Monkey._generateBaseWrapperElement($monkeyContainer, options));
     }
 
     var generateUrls = (this.options.platformAPI)
@@ -93,10 +98,7 @@
       .then(generateUrls)
       .then(Monkey._generateHtml(options.lang));
 
-    if (this.options.platformAPI) {
-      promise = promise
-        .then(Monkey._generateBaseElement($monkeyContainer, options));
-    }
+
 
     if (options.slider) {
       promise = promise


### PR DESCRIPTION
As part of the work to maintian a set height of the monkey preview, even when the book isn't loading, we separated out the initial parent element.

With the `platformAPI` option set, however, this new chained method was missed, resulting in an `undefined` error. This PR fixes that by ensuring the new method is called in both cases.