### PR TITLE
Ensure the updateCharSelection() function is called on init [SHOP-4470]

### DIFF
--- a/src/js/steps/letters/init.js
+++ b/src/js/steps/letters/init.js
@@ -448,6 +448,8 @@ module.exports = function ($events, options, $monkeyContainer) {
       $events.trigger('charactersChanged', { characters: charactersArray });
     };
 
+    data.updateCharSelection();
+
     /**
      * Wrapper function for other functions which all contribute to changing the
      * character within a letter. It changes the thumbnail, changes the button


### PR DESCRIPTION
This fixes the issue mentioned in https://lostmyjira.atlassian.net/browse/SHOP-4470 whereby if a user changes the characters in a book, then changes the name again, wrong characters get applied to the product, meaning that the user can't checkout with that product.

The fix is to ensure the `updateCharSelection` method is called when the Monkey is initialized, as well as the characters changed.