### PR TITLE
Reorder the promise chain to always render the baseWrapperElement

### DIFF
--- a/src/js/monkey.js
+++ b/src/js/monkey.js
@@ -67,11 +67,17 @@
         return data;
       });
 
+    if (options.letters || this.options.platformAPI) {
+      promise = promise
+        .then(Monkey._generateBaseElement($monkeyContainer, options));
+    }
+
+    promise = promise
+      .then(Monkey._generateBaseWrapperElement($monkeyContainer, options));
+
     if (options.letters) {
       promise = promise
-        .then(Monkey._generateBaseElement($monkeyContainer, options))
-        .then(Monkey.letters._generateHtml(options))
-        .then(Monkey._generateBaseWrapperElement($monkeyContainer, options));
+        .then(Monkey.letters._generateHtml(options));
 
       if (options.showCharPicker) {
         promise = promise
@@ -82,12 +88,6 @@
         );
       }
       promise = promise.then(Monkey.letters._init(this.$events, options, $monkeyContainer));
-    }
-
-    if (this.options.platformAPI) {
-      promise = promise
-        .then(Monkey._generateBaseElement($monkeyContainer, options))
-        .then(Monkey._generateBaseWrapperElement($monkeyContainer, options));
     }
 
     var generateUrls = (this.options.platformAPI)


### PR DESCRIPTION
Due to the new way of building the Monkey HTML, if a Monkey instance was being displayed without either letter controls, or the platformAPI option set to true, the Monkey would fail.

By re-ordering the instantiation of Monkey, we can ensure that the baseWrapperElement which was failing before will always be present, no matter what the configuration.