### PR TITLE
Cater for mobile single spreads

### DIFF
--- a/src/js/monkeys/mobile.js
+++ b/src/js/monkeys/mobile.js
@@ -51,12 +51,6 @@ mobile.generateHtml = function (data, lang) {
 
   return data.$monkeyWrapper;
 };
-/*eslint-disable no-unused-vars */
-mobile.generateBaseElement = function (data) {
-  return $('<div />')
-    .addClass('monkey mobile');
-};
-/*eslint-enable no-unused-vars */
 
 // @todo document this
 mobile.init = function (data, $events) {
@@ -72,20 +66,23 @@ mobile.init = function (data, $events) {
 
   function setWidths() {
     var widthModifier = 1.5;
-    var width = $window.width() * widthModifier;
+    var widthInitial = data.spreads === 'single' ? $window.width() / 2 : $window.width();
+    var width = widthInitial * widthModifier;
     var height = Math.ceil(width / RATIO);
     var $page = $('.page');
-
-    $('.landscape-images-inner').width(width * ($page.length + 1));
+    var pageModifier = data.spreads === 'single' ? 2 : 1;
+    $('.landscape-images-inner').width(width * ($page.length + pageModifier));
 
     $page.children('img').css({
       height: height,
       width: Math.ceil(width)
     });
 
-    $('.page-halfwidth')
-      .css('width', Math.ceil(width / 2))
-      .find('img').css('height', height);
+    if (data.spreads !== 'single') {
+      $('.page-halfwidth')
+        .css('width', Math.ceil(width / 2))
+        .find('img').css('height', height);
+    }
 
     $monkey.scrollLeft($monkey.find('img').width() * windowLeft);
   }

--- a/src/js/steps/generateBaseWrapperElement.js
+++ b/src/js/steps/generateBaseWrapperElement.js
@@ -10,7 +10,7 @@ var $ = require('jquery');
 module.exports = function ($monkeyContainer) {
   return function (data) {
     var classes = data.monkeyType === 'mobile' ?
-                  'monkey-wrapper mobile' :
+                  'monkey-wrapper mobile spreads-' + data.spreads :
                   'positioned-relative pos-relative monkey-wrapper desktop';
 
     data.$monkeyWrapper = $('<div />').addClass(classes);

--- a/src/scss/monkey/_mobile.scss
+++ b/src/scss/monkey/_mobile.scss
@@ -74,9 +74,16 @@
 .page {
   position: relative;
   float: left;
-  min-width: 490px;
   padding-right: 10px;
   overflow: hidden;
+
+  .spreads-double & {
+    min-width: 490px;
+  }
+
+  .spreads-single & {
+    min-width: 290px;
+  }
 
   .landscape & {
     background: #333333;
@@ -89,12 +96,18 @@
 
   img {
     position: relative;
-    left: -100%;
+
+    .spreads-double & {
+      left: -100%;
+    }
   }
 }
 
 .page-halfwidth {
-  min-width: 0;
+  .spreads-single &,
+  .spreads-double & {
+    min-width: 0;
+  }
 }
 
 #letters-container {

--- a/test/mobile.spec.js
+++ b/test/mobile.spec.js
@@ -28,6 +28,10 @@ describe('Using monkey on mobile', function () {
     $container.children().length.should.equal(2);
   });
 
+  it('should have the spreads-double class applied to it', function () {
+    $monkey.hasClass('spreads-double').should.equal(true);
+  });
+
   it('should scroll', function () {
     $monkey.scrollLeft(100);
     $monkey.scrollLeft().should.equal(100);


### PR DESCRIPTION
We want to support the J Home book on mobile devices, and as such we need to support single-spread payloads from the server.

## Before:
<img width="375" alt="screenshot 2016-06-01 16 07 49" src="https://cloud.githubusercontent.com/assets/2562596/15714593/0687f040-2813-11e6-8d77-6d1219ec00f9.png">
## After:
<img width="376" alt="screenshot 2016-06-01 16 07 19" src="https://cloud.githubusercontent.com/assets/2562596/15714602/0f9da648-2813-11e6-935c-ff3cdf6ad18f.png">
