### PR TITLE
Support TJH turnToPage on Mobile

### DIFF
--- a/src/js/monkeys/mobile.js
+++ b/src/js/monkeys/mobile.js
@@ -58,10 +58,11 @@ mobile.init = function (data, $events) {
   ++numberOfMonkeys;
 
   var $monkey = data.html;
-  $monkey.parents('#monkey').addClass('mobile');
+  var $monkeyParent = $monkey.parents('#monkey');
+  $monkeyParent.addClass('mobile');
   var RATIO = this.Monkey.IMAGE_RATIO;
   // If it's the TJH book, we want to enable animating when using the turnToPage function
-  data.animateToPage = $('#monkey').attr('data-key') === 'tjh-book';
+  data.animateToPage = $monkeyParent.attr('data-key') === 'tjh-book';
 
   $window.on('orientationchange resize', setWidths);
   setTimeout(setWidths);

--- a/src/js/monkeys/mobile.js
+++ b/src/js/monkeys/mobile.js
@@ -60,7 +60,6 @@ mobile.init = function (data, $events) {
   var $monkey = data.html;
   $monkey.parents('#monkey').addClass('mobile');
   var RATIO = this.Monkey.IMAGE_RATIO;
-  // console.log($('#monkey'));
   // If it's the TJH book, we want to enable animating when using the turnToPage function
   data.animateToPage = $('#monkey').attr('data-key') === 'tjh-book';
 
@@ -187,7 +186,7 @@ mobile.letterHandler = function (data, $events) {
   // index is the letter index
   return function turnToPage(index) {
     var $pages = data.html.find('.page');
-    var factor = data.spreads === 'single' ? index : (index * 2 - 1);
+    var factor = data.spreads === 'single' ? index : (index * 2 + 1);
     var $page = $pages.eq(factor);
     var offset = $page.offset().left - $page.parent().offset().left;
     var INITIAL_SPEED = 500;

--- a/src/scss/monkey/_mobile.scss
+++ b/src/scss/monkey/_mobile.scss
@@ -98,7 +98,7 @@
 }
 
 .page-halfwidth {
-  min-width: 0;
+  min-width: 245px;
 }
 
 #letters-container {

--- a/test/mobile.spec.js
+++ b/test/mobile.spec.js
@@ -46,7 +46,6 @@ describe('Using monkey on mobile', function () {
 
   it('should fire event when scrolled', function (cb) {
     this.timeout(500); // If it isn't fired in this time, it won't be
-
     monkey.$events.on('halfway', function () {
       cb();
     });
@@ -55,5 +54,59 @@ describe('Using monkey on mobile', function () {
 
   after(function () {
     $container.remove();
+  });
+});
+
+describe('Using TJH monkey on mobile', function () {
+  var $monkey, monkey, monkeyData;
+  var $container = $('<div />')
+    .attr('id', 'monkey')
+    .attr('data-key', 'tjh-book')
+    .attr('data-server', 'https://prod1-platform.lostmy.name/');
+
+  before(function () {
+    monkey = new Monkey($container, {
+      monkeyType: 'mobile',
+      platformAPI: true,
+      letters: false,
+      server: 'https://prod1-platform.lostmy.name/',
+      book: {
+        name: 'Tal',
+        gender: 'boy',
+        locale: 'en-gb',
+        inscription: 'test',
+        country_code: 'gb', // eslint-disable-line camelcase
+        address: '',
+        door_number: '10', // eslint-disable-line camelcase
+        lat: '51.171223',
+        lng: '-1.789289',
+        phototype: 'type-ii'
+      }
+    });
+
+    return monkey.promise.then(function (data) {
+      data.animateToPage = true;
+      data.html.trigger('touchstart');
+      monkeyData = data;
+      $monkey = $container.find('.monkey-wrapper');
+      $container.appendTo('body');
+    });
+  });
+
+  it('should be initiated', function () {
+    $container.children().length.should.equal(1);
+  });
+
+  it('should have the animateToPage value set to true', function () {
+    monkeyData.animateToPage.should.equal(true);
+  });
+
+  it('should change the page with the turnToPage function', function (done) {
+    monkey.turnToPage(5);
+    setTimeout(function () {
+      if ($monkey.scrollLeft() > 0) {
+        done();
+      }
+    }, 500);
   });
 });


### PR DESCRIPTION
Add ability for turning to a specific page on the mobile monkey upon render.

This is done by adding a `data.animateToPage` boolean which depends on whether we're viewing the TJH book.

Then we check for this boolean, and how many times the monkey has re-rendered on the page to see whether we should enable the jiggling of the Monkey to show that you can slide it left/right.

In the turnToPage function itself, we are checking that boolean to either animate the scroll position, or set it explicitly.

This PR also provides the functionality to separate the single & double spreads up to have accurate page turns for both kinds of spreads.