### PR TITLE
Support Apostrophes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmn-monkey",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "",
   "main": "src/js/monkey.js",
   "dependencies": {

--- a/src/js/helpers/blankLetterCheck.js
+++ b/src/js/helpers/blankLetterCheck.js
@@ -1,0 +1,1 @@
+module.exports = /^[\s\-\'\’]$/;

--- a/src/js/steps/letters/generateHtml.js
+++ b/src/js/steps/letters/generateHtml.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var $ = require('jquery');
+var blankLetterCheck = require('../../helpers/blankLetterCheck');
 // var isMobile = require('../../helpers/isMobile')();
 
 // The minimum length for a name is 4 not including a space or -
@@ -54,7 +55,7 @@ module.exports = function (options) {
 
     // If name short, add blank letter for extra story
     var paddedLetters = $.map(letters, function (el) {
-      if (el !== '' && el !== '-' && el !== ' ') {
+      if (!blankLetterCheck.test(el)) {
         return el;
       }
     });
@@ -86,8 +87,7 @@ module.exports = function (options) {
     var loadLetterCards = function () {
       $(combinedLetters).each(function (i, letter) {
         var $letterDiv = $('<div />');
-
-        if (letter.letter === ' ' || letter.letter === '-') {
+        if (blankLetterCheck.test(letter.letter)) {
           $letterDiv.addClass('special-char nonclickable');
         }
 
@@ -186,7 +186,7 @@ function combineLetters(splitLetters, dataLetters) {
     dataLetters[idx].changed =
       dataLetters[idx].selected !== dataLetters[idx].default_character;
 
-    if (val === '-' || val === ' ') {
+    if (blankLetterCheck.test(val)) {
       offset++;
       return { letter: val };
     }


### PR DESCRIPTION
We want Monkey to be able to support apostrophes and single quotations as these are valid characters as part of the updated name validation for LMN.

So this refactors the current checks for 'blank' characters (previously a space and a hyphen) & makes it more DRY by using a helper to create the RegExp.