### PR TITLE
Fix the logic to show the char picker language overlay

### DIFF
--- a/src/js/steps/checkLanguageChange.js
+++ b/src/js/steps/checkLanguageChange.js
@@ -17,7 +17,7 @@ module.exports = function ($monkeyContainer, options) {
     delete options.book.characterSelection;
     $monkeyContainer.data('character-selection', null);
     options.clearSelection = true;
-    if (options.showCharPicker && $monkeyContainer.data('changedChars')) {
+    if (!options.showCharPicker && $monkeyContainer.data('changedChars')) {
       options.showLanguageOverlay = true;
     }
     $monkeyContainer.data('locale', options.book.locale);


### PR DESCRIPTION
The logic to show the 'language changed' overlay in the Character Picker was incorrect. The current check returns true when changing language to a language that supports the Character Picker. In fact, it should show the overlay when changing language to a language that doesn't support the Character Picker.